### PR TITLE
chore: use provided nix-env --delete-generations variant

### DIFF
--- a/install/gnome.themes.nix
+++ b/install/gnome.themes.nix
@@ -1,12 +1,34 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
 {
-  home-manager.users.${config.user}.dconf = {
-    inherit (config.programs.dconf) enable;
+  home-manager.users.${config.user} = {
+    dconf = {
+      inherit (config.programs.dconf) enable;
 
-    settings."org/gnome/desktop/background" = {
-      picture-uri = "file://${config.root}/resources/gnome/wallpaper-bright.jpg";
-      picture-uri-dark = "file://${config.root}/resources/gnome/wallpaper-dark.jpg";
+      settings."org/gnome/desktop/background" = {
+        picture-uri = "file://${config.root}/resources/gnome/wallpaper-bright.jpg";
+        picture-uri-dark = "file://${config.root}/resources/gnome/wallpaper-dark.jpg";
+      };
+    };
+
+    gtk = {
+      enable = true;
+      colorScheme = "dark";
+
+      theme = {
+        name = "adw-gtk3-dark";
+        package = pkgs.adw-gtk3;
+      };
+
+      gtk4.theme = {
+        name = "adw-gtk3-dark";
+        package = pkgs.adw-gtk3;
+      };
+
+      iconTheme = {
+        name = "Adwaita";
+        package = pkgs.adwaita-icon-theme;
+      };
     };
   };
 

--- a/install/please.nix
+++ b/install/please.nix
@@ -7,10 +7,14 @@ let
     # ---------- clean ---------- #
     if [ "$1" = "clean" ]; then
 
-    # limit the number of generations to 10 (-1 as the current generation is not counted)
-    # remove all except the last 9 lines from --list-generations and feed them into --delete-generations
-    delete_gen=$(sudo nix-env --list-generations --profile /nix/var/nix/profiles/system | head -n -9 | awk '{print $1}' | tr '\n' ' ')
-    sudo nix-env --delete-generations --profile /nix/var/nix/profiles/system $delete_gen
+    N=''${2:-10};
+    # limit the number of generations to $N;
+    sudo nix-env --delete-generations +$N;
+
+    n=$(sudo nix-env --list-generations --profile /nix/var/nix/profiles/system | wc -l);
+    if [ $n -gt $N ]; then
+      echo "Just a heads-up that more than the expected $N generations are currently alive. This is likely due to you having had rolled back from the latest generation before running this command."
+    fi
 
     sudo nix-collect-garbage
 


### PR DESCRIPTION
# Description
This PR changes the logic of `please clean` in a couple of ways.
1. It allows users to provide the value for the number of generations at call-time (defaults to 10, preserving backward-compatibility).
2. It uses the built-in `+N` feature of `--list-generations` to list the last `n` generations, instead of using `head` and `awk` and `tr`.